### PR TITLE
Use OS key for Windows/Add a to document for Firefox

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,14 +55,17 @@
     autosize($$('textarea'))
     setInterval(autoSave, 1000)
     document.addEventListener('keydown', (e)=>{
-      if(e.metaKey && e.key == 's'){
+      if((e.metaKey || e.getModifierState("OS")) && e.key == 's'){
         e.preventDefault()
         const blob = new Blob([getText()], {type: 'text/plain'})
         const a = document.createElement('a')
+        document.body.appendChild(a);
+        a.setAttribute("type", "hidden");
         a.href = URL.createObjectURL(blob)
         a.target = '_blank'
         a.download = `${getText().split("\n")[0]}.txt`
         a.click()
+        document.body.removeChild(a);
       }
     })
   </script>


### PR DESCRIPTION
# Windows対応

WindowsではmetaKeyが発火しないのでgetModifierState("OS")でOSKey(WindowsKey)でもOKにした。

# Firefox対応

documentにくっつけないとa.click()がうごかんからうまいことやった
